### PR TITLE
Add basic smoke test job on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,18 @@ jobs:
             fi
 
       - run:
+          name: Run a Simple Python Script
+          command: |
+            OUTPUT="$(python -c 'print("Hello from Python")')"
+            echo "${OUTPUT}"
+            if [ "${OUTPUT}" = 'Hello from Python' ]; then
+              true
+            else
+              echo 'Did not get expected output!'
+              false
+            fi
+
+      - run:
           name: Upgrade Pip
           command: |
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+
+jobs:
+  smoke_test:
+    docker:
+      - image: mr0grog/circle-python-pre:3.13.0a2
+    steps:
+      - run:
+          name: Check Python Version
+          command: |
+            ACTUAL_VERSION="$(python --version)"
+            echo "'python --version' == '${ACTUAL_VERSION}'"
+            if [ "${ACTUAL_VERSION}" = 'Python 3.13.0a2' ]; then
+              true
+            else
+              echo 'Did not find expected Python version!'
+              false
+            fi
+
+      - run:
+          name: Upgrade Pip
+          command: |
+            pip install --upgrade pip
+
+workflows:
+  ci:
+    jobs:
+      - smoke_test


### PR DESCRIPTION
Ideally we'd do the build on Circle, then trigger the smoke test after, but I did the build on GH actions because I was lazy. Maybe I'll fix that someday. For now, this just runs a job on Circle using the image, and does a couple basic checks to make sure things work.