### PR TITLE
Update Readme and tests for 3.13.0a5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2.1
 jobs:
   smoke_test:
     docker:
-      - image: mr0grog/circle-python-pre:3.13.0a3
+      - image: mr0grog/circle-python-pre:3.13.0a5
     steps:
       - run:
           name: Check Python Version
           command: |
             ACTUAL_VERSION="$(python --version)"
             echo "'python --version' == '${ACTUAL_VERSION}'"
-            if [ "${ACTUAL_VERSION}" = 'Python 3.13.0a3' ]; then
+            if [ "${ACTUAL_VERSION}" = 'Python 3.13.0a5' ]; then
               true
             else
               echo 'Did not find expected Python version!'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ CircleCI doesn't make official `cimg/python` images available for Python pre-rel
     - (No 3.13.0a1 release)
     - 3.13.0a2
     - 3.13.0a3
+    - (No 3.13.0a4 release; Pyenv never supported it)
+    - 3.13.0a5
 
 This is pretty much a copy of the official CircleCI image with some small tweaks. CircleCI's source can be found at: https://github.com/CircleCI-Public/cimg-python/
 
@@ -23,7 +25,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: mr0grog/circle-python-pre:3.13.0a3
+      - image: mr0grog/circle-python-pre:3.13.0a5
     steps:
       - checkout
       - run:
@@ -45,6 +47,6 @@ workflows:
 
 ## License & Copyright
 
-Copyright (C) 2023 Rob Brackett. See the [`LICENSE`](./LICENSE) file for details.
+Copyright (C) 2023-2024 Rob Brackett. See the [`LICENSE`](./LICENSE) file for details.
 
 Most of the Dockerfile is a fork of CircleCI's official image, which is also MIT-licensed: https://github.com/CircleCI-Public/cimg-python/


### PR DESCRIPTION
This is a followup to building 3.13.0a5. ⚠️ **Should not land until the image actually publishes successfully!**