### PR TITLE
Add Python 3.14.0a7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ workflows:
   ci:
     jobs:
       - smoke_test:
-          version: 3.14.0a6
+          version: 3.14.0a7
       - smoke_test:
           name: smoke_test-freethreading
-          version: 3.14.0a6t
+          version: 3.14.0a7t

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 env:
   IMAGE_NAME: mr0grog/circle-python-pre
-  VERSIONS: '["3.14.0a6", "3.14.0a6t"]'
+  VERSIONS: '["3.14.0a7", "3.14.0a7t"]'
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ CircleCI doesn't make official `cimg/python` images available for Python pre-rel
     - 3.14.0a4, 3.14.0a4t (The `t` image does not have Poetry.)
     - 3.14.0a5, 3.14.0a5t (The `t` image does not have Poetry.)
     - 3.14.0a6, 3.14.0a6t (The `t` image does not have Poetry.)
+    - 3.14.0a7, 3.14.0a7t (The `t` image does not have Poetry.)
 
 This is pretty much a copy of the official CircleCI image with some small tweaks. CircleCI's source can be found at: https://github.com/CircleCI-Public/cimg-python/
 
@@ -43,7 +44,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: mr0grog/circle-python-pre:3.14.0a6
+      - image: mr0grog/circle-python-pre:3.14.0a7
     steps:
       - checkout
       - run:


### PR DESCRIPTION
**This will fail for now,** since Pyenv does not yet have 3.14.0a7. [There was a PR](https://github.com/pyenv/pyenv/pull/3231), but it was closed without merging. Not sure on the current state or when something will land.

Release announcement: https://pythoninsider.blogspot.com/2025/04/python-3140a7-3133-31210-31112-31017.html