### PR TITLE
Build Python 3.14.0b3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ workflows:
   ci:
     jobs:
       - smoke_test:
-          version: 3.14.0b2
+          version: 3.14.0b3
       - smoke_test:
           name: smoke_test-freethreading
-          version: 3.14.0b2t
+          version: 3.14.0b3t

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 env:
   IMAGE_NAME: mr0grog/circle-python-pre
-  VERSIONS: '["3.14.0b2", "3.14.0b2t"]'
+  VERSIONS: '["3.14.0b3", "3.14.0b3t"]'
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ CircleCI doesn't make official `cimg/python` images available for Python pre-rel
     - 3.14.0a6, 3.14.0a6t (The `t` image does not have Poetry.)
     - 3.14.0a7, 3.14.0a7t (The `t` image does not have Poetry.)
     - 3.14.0b1, 3.14.0b1t (The `t` image does not have Poetry.)
-    - 3.14.0b2, 3.14.0b2t (The `t` image does not have Poetry.)
+    - 3.14.0b3, 3.14.0b3t (The `t` image does not have Poetry.)
 
 This is pretty much a copy of the official CircleCI image with some small tweaks. CircleCI's source can be found at: https://github.com/CircleCI-Public/cimg-python/
 
@@ -46,7 +46,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: mr0grog/circle-python-pre:3.14.0b2
+      - image: mr0grog/circle-python-pre:3.14.0b3
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Release announcement: https://pythoninsider.blogspot.com/2025/06/python-3140-beta-3-is-here.html