### PR TITLE
Only log in to Docker Hub if publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Login to Docker Hub
+        if: ${{ inputs.publish }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Dependabot PRs should really be able to do basic builds without pushing to Docker Hub, so we can at least get some better PR checks on dependency updates.