### PR TITLE
Build Python 3.14.0rc3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
       version:
         description: 'Expected version of Python to be used'
         type: string
+      poetry:
+        description: 'Whether to test Poetry support'
+        type: boolean
     docker:
       - image: "mr0grog/circle-python-pre:<< parameters.version >>"
     steps:
@@ -21,11 +24,21 @@ jobs:
           command: |
             pip install --upgrade pip
 
+      - when:
+          condition: << parameters.poetry >>
+          steps:
+            - run:
+                name: Check Poetry
+                command: |
+                  poetry --help
+
 workflows:
   ci:
     jobs:
       - smoke_test:
-          version: 3.14.0rc2
+          version: 3.14.0rc3
+          poetry: true
       - smoke_test:
           name: smoke_test-freethreading
-          version: 3.14.0rc2
+          version: 3.14.0rc3
+          poetry: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 env:
   IMAGE_NAME: mr0grog/circle-python-pre
-  VERSIONS: '["3.14.0rc2", "3.14.0rc2t"]'
+  VERSIONS: '["3.14.0rc3", "3.14.0rc3t"]'
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ CircleCI doesn't make official `cimg/python` images available for Python pre-rel
     - 3.14.0b4, 3.14.0b4t (The `t` image does not have Poetry.)
     - 3.14.0rc1, 3.14.0rc1t (The `t` image does not have Poetry.)
     - 3.14.0rc2, 3.14.0rc2t (The `t` image does not have Poetry.)
+    - 3.14.0rc3, 3.14.0rc3t
 
 This is pretty much a copy of the official CircleCI image with some small tweaks. CircleCI's source can be found at: https://github.com/CircleCI-Public/cimg-python/
 
@@ -49,7 +50,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: mr0grog/circle-python-pre:3.14.0rc2
+      - image: mr0grog/circle-python-pre:3.14.0rc3
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Release announcement: https://blog.python.org/2025/09/python-3140rc3-is-go.html