### PR TITLE
Build Python 3.15.0b2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ workflows:
   ci:
     jobs:
       - smoke_test:
-          version: 3.15.0b1
+          version: 3.15.0b2
           poetry: true
       - smoke_test:
           name: smoke_test-freethreading
-          version: 3.15.0b1t
+          version: 3.15.0b2t
           poetry: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 env:
   IMAGE_NAME: mr0grog/circle-python-pre
-  VERSIONS: '["3.15.0b1", "3.15.0b1t"]'
+  VERSIONS: '["3.15.0b2", "3.15.0b2t"]'
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ CircleCI doesn't make official `cimg/python` images available for Python pre-rel
     - 3.15.0a7, 3.15.0a7t (The `t` image does not have Poetry.)
     - 3.15.0a8, 3.15.0a8t (The `t` image does not have Poetry.)
     - 3.15.0b1, 3.15.0b1t
+    - 3.15.0b2, 3.15.0b2t
 
 This is pretty much a copy of the official CircleCI image with some small tweaks. CircleCI's source can be found at: https://github.com/CircleCI-Public/cimg-python/
 
@@ -61,7 +62,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: mr0grog/circle-python-pre:3.15.0b1
+      - image: mr0grog/circle-python-pre:3.15.0b2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Release announcement: https://blog.python.org/2026/06/python-3150-beta-2/