### PR TITLE
Build Python 3.15.0rc1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ workflows:
   ci:
     jobs:
       - smoke_test:
-          version: 3.15.0b4
+          version: 3.15.0rc1
           poetry: true
       - smoke_test:
           name: smoke_test-freethreading
-          version: 3.15.0b4t
+          version: 3.15.0rc1t
           poetry: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 env:
   IMAGE_NAME: mr0grog/circle-python-pre
-  VERSIONS: '["3.15.0b4", "3.15.0b4t"]'
+  VERSIONS: '["3.15.0rc1", "3.15.0rc1t"]'
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ CircleCI doesn't make official `cimg/python` images available for Python pre-rel
     - 3.15.0b2, 3.15.0b2t
     - 3.15.0b3, 3.15.0b3t
     - 3.15.0b4, 3.15.0b4t
+    - 3.15.0rc1, 3.15.0rc1t
 
 This is pretty much a copy of the official CircleCI image with some small tweaks. CircleCI's source can be found at: https://github.com/CircleCI-Public/cimg-python/
 
@@ -64,7 +65,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: mr0grog/circle-python-pre:3.15.0b4
+      - image: mr0grog/circle-python-pre:3.15.0rc1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Release announcement: https://blog.python.org/2026/08/python-3150-rc1/